### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -3,6 +3,9 @@ on:
     release:
         types: [published]
 
+permissions:
+    contents: read
+
 jobs:
     github-releases-to-discord:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ilianoKokoro/umihi-music/security/code-scanning/3](https://github.com/ilianoKokoro/umihi-music/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained.  
Best fix here (without changing behavior) is to set workflow-level minimal read access:

- Edit `.github/workflows/github-releases-to-discord.yml`
- Insert at the top level (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`

This addresses the CodeQL finding and documents intended token scope for all jobs in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
