### PR TITLE
fix: label ui elements correctly for TalkBack screen reader

### DIFF
--- a/app/src/main/java/ca/ilianokokoro/umihi/music/ui/components/miniplayer/MiniPlayer.kt
+++ b/app/src/main/java/ca/ilianokokoro/umihi/music/ui/components/miniplayer/MiniPlayer.kt
@@ -142,7 +142,7 @@ fun MiniPlayer(
                                 }
                                 Icon(
                                     imageVector = icon,
-                                    contentDescription = icon.name,
+                                    contentDescription = stringResource(R.string.play),
                                     modifier = Modifier.size(20.dp)
                                 )
                             }

--- a/app/src/main/java/ca/ilianokokoro/umihi/music/ui/screens/player/components/PlayerControls.kt
+++ b/app/src/main/java/ca/ilianokokoro/umihi/music/ui/screens/player/components/PlayerControls.kt
@@ -169,7 +169,7 @@ fun PlayerControls(
                                 }
                                 Icon(
                                     imageVector = icon,
-                                    contentDescription = icon.name,
+                                    contentDescription = stringResource(R.string.play),
                                     modifier = Modifier.size(50.dp)
                                 )
                             }

--- a/app/src/main/java/ca/ilianokokoro/umihi/music/ui/screens/settings/components/BooleanSettingItem.kt
+++ b/app/src/main/java/ca/ilianokokoro/umihi/music/ui/screens/settings/components/BooleanSettingItem.kt
@@ -58,7 +58,7 @@ fun BooleanSettingItem(
             ) {
                 Icon(
                     imageVector = leadingIcon,
-                    contentDescription = leadingIcon.name,
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.secondary
                 )
 

--- a/app/src/main/java/ca/ilianokokoro/umihi/music/ui/screens/settings/components/SettingItem.kt
+++ b/app/src/main/java/ca/ilianokokoro/umihi/music/ui/screens/settings/components/SettingItem.kt
@@ -50,7 +50,7 @@ fun SettingsItem(
             ) {
                 Icon(
                     imageVector = leadingIcon,
-                    contentDescription = leadingIcon.name,
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.secondary
                 )
 
@@ -82,7 +82,7 @@ fun SettingsItem(
                 ) {
                     Icon(
                         imageVector = trailingIcon,
-                        contentDescription = trailingIcon.name,
+                        contentDescription = null,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }


### PR DESCRIPTION
Instead of reporting the icon name, specify the action being performed of the play/pause button in player and mini player. Although the button will be always read as "Play" even if the player is paused, the status of the toggle is also reported, so one can know that play is pressed because TalkBack will read "Checked Play", while when it is paused will read "Unchecked Play". Set null for contentDescription in SettingItem and BooleanSetting item to avoid icon name beeing read. TalkBack already reports correctly the title and subtitle.