### PR TITLE
feat(ui): add swipe gestures to miniplayer (closes #26)

### DIFF
--- a/app/src/main/java/ca/ilianokokoro/umihi/music/ui/components/miniplayer/MiniPlayer.kt
+++ b/app/src/main/java/ca/ilianokokoro/umihi/music/ui/components/miniplayer/MiniPlayer.kt
@@ -1,11 +1,17 @@
 package ca.ilianokokoro.umihi.music.ui.components.miniplayer
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -24,21 +30,39 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import ca.ilianokokoro.umihi.music.R
 import ca.ilianokokoro.umihi.music.core.helpers.ComposeHelper
 import ca.ilianokokoro.umihi.music.models.Song
 import ca.ilianokokoro.umihi.music.ui.components.SquareImage
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+private enum class MiniPlayerDragDirection {
+    HORIZONTAL,
+    VERTICAL
+}
 
 @Composable
 fun MiniPlayer(
     modifier: Modifier = Modifier,
     currentSong: Song,
     onClick: () -> Unit,
+    onDismiss: () -> Unit = {},
     onPlayPause: () -> Unit,
     onSkipNext: () -> Unit,
     onSkipPrevious: () -> Unit,
@@ -46,10 +70,152 @@ fun MiniPlayer(
     isLoading: Boolean,
 ) {
     val controlsInteractionSources = List(3) { ComposeHelper.rememberInteractionSource() }
+    val coroutineScope = rememberCoroutineScope()
+    val hapticFeedback = LocalHapticFeedback.current
+    val density = LocalDensity.current
+
+    val offsetX = remember { Animatable(0f) }
+    val offsetY = remember { Animatable(0f) }
+
+    val horizontalThresholdPx = with(density) { 48.dp.toPx() }
+    val verticalThresholdPx = with(density) { 36.dp.toPx() }
+    val velocityThresholdPx = with(density) { 500.dp.toPx() }
+    val maxHorizontalDragPx = with(density) { 150.dp.toPx() }
+    val maxVerticalUpDragPx = with(density) { 50.dp.toPx() }
+    val maxVerticalDownDragPx = with(density) { 90.dp.toPx() }
+
+    val gestureModifier = Modifier.pointerInput(Unit) {
+        val touchSlop = viewConfiguration.touchSlop
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false)
+            val velocityTracker = VelocityTracker()
+            velocityTracker.addPosition(down.uptimeMillis, down.position)
+
+            var totalDragX = 0f
+            var totalDragY = 0f
+            var isDragging = false
+            var dragDirection: MiniPlayerDragDirection? = null
+            var gestureCompletedNormally = false
+
+            try {
+                while (true) {
+                    val event = awaitPointerEvent()
+                    val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                    if (!change.pressed) {
+                        break
+                    }
+
+                    velocityTracker.addPosition(change.uptimeMillis, change.position)
+                    val dragAmount = change.positionChange()
+                    totalDragX += dragAmount.x
+                    totalDragY += dragAmount.y
+
+                    if (!isDragging) {
+                        val absX = abs(totalDragX)
+                        val absY = abs(totalDragY)
+                        if (absX > touchSlop || absY > touchSlop) {
+                            isDragging = true
+                            dragDirection =
+                                if (absX >= absY) MiniPlayerDragDirection.HORIZONTAL
+                                else MiniPlayerDragDirection.VERTICAL
+                            change.consume()
+                        }
+                    } else {
+                        change.consume()
+                        if (dragDirection == MiniPlayerDragDirection.HORIZONTAL) {
+                            coroutineScope.launch {
+                                val newX = (offsetX.value + dragAmount.x)
+                                    .coerceIn(-maxHorizontalDragPx, maxHorizontalDragPx)
+                                offsetX.snapTo(newX)
+                            }
+                        } else if (dragDirection == MiniPlayerDragDirection.VERTICAL) {
+                            coroutineScope.launch {
+                                val damping = if (dragAmount.y < 0) 0.5f else 0.8f
+                                val newY = (offsetY.value + dragAmount.y * damping)
+                                    .coerceIn(-maxVerticalUpDragPx, maxVerticalDownDragPx)
+                                offsetY.snapTo(newY)
+                            }
+                        }
+                    }
+                }
+
+                if (isDragging) {
+                    val velocity = velocityTracker.calculateVelocity()
+                    if (dragDirection == MiniPlayerDragDirection.HORIZONTAL) {
+                        val currentX = offsetX.value
+                        val vx = velocity.x
+                        if (currentX < -horizontalThresholdPx || vx < -velocityThresholdPx) {
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                            onSkipNext()
+                        } else if (currentX > horizontalThresholdPx || vx > velocityThresholdPx) {
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                            onSkipPrevious()
+                        }
+                        coroutineScope.launch {
+                            offsetX.animateTo(
+                                targetValue = 0f,
+                                animationSpec = spring(
+                                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                                    stiffness = Spring.StiffnessLow
+                                )
+                            )
+                        }
+                    } else if (dragDirection == MiniPlayerDragDirection.VERTICAL) {
+                        val currentY = offsetY.value
+                        val vy = velocity.y
+                        if (currentY < -verticalThresholdPx || vy < -velocityThresholdPx) {
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                            onClick()
+                        } else if (currentY > verticalThresholdPx || vy > velocityThresholdPx) {
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                            onDismiss()
+                        }
+                        coroutineScope.launch {
+                            offsetY.animateTo(
+                                targetValue = 0f,
+                                animationSpec = spring(
+                                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                                    stiffness = Spring.StiffnessLow
+                                )
+                            )
+                        }
+                    }
+                }
+                gestureCompletedNormally = true
+            } finally {
+                if (!gestureCompletedNormally) {
+                    if (offsetX.value != 0f) {
+                        coroutineScope.launch {
+                            offsetX.animateTo(
+                                targetValue = 0f,
+                                animationSpec = spring(
+                                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                                    stiffness = Spring.StiffnessLow
+                                )
+                            )
+                        }
+                    }
+                    if (offsetY.value != 0f) {
+                        coroutineScope.launch {
+                            offsetY.animateTo(
+                                targetValue = 0f,
+                                animationSpec = spring(
+                                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                                    stiffness = Spring.StiffnessLow
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     Card(
         modifier = modifier
             .fillMaxWidth()
+            .offset { IntOffset(offsetX.value.roundToInt(), offsetY.value.roundToInt()) }
+            .then(gestureModifier)
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHighest

--- a/app/src/main/java/ca/ilianokokoro/umihi/music/ui/components/miniplayer/MiniPlayerWrapper.kt
+++ b/app/src/main/java/ca/ilianokokoro/umihi/music/ui/components/miniplayer/MiniPlayerWrapper.kt
@@ -31,6 +31,7 @@ import ca.ilianokokoro.umihi.music.extensions.toSong
 fun MiniPlayerWrapper(
     modifier: Modifier = Modifier,
     onMiniPlayerPressed: () -> Unit,
+    onDismiss: () -> Unit = { PlayerManager.clearQueue() },
     showMiniPlayer: Boolean,
 ) {
     val player by PlayerManager.controllerState.collectAsStateWithLifecycle()
@@ -92,6 +93,7 @@ fun MiniPlayerWrapper(
         MiniPlayer(
             currentSong = song,
             onClick = onMiniPlayerPressed,
+            onDismiss = onDismiss,
             onPlayPause = {
                 if (player?.isPlaying == true) {
                     player?.pause()


### PR DESCRIPTION
## Description
Resolves #26.

Adds intuitive and interactive gesture controls to the MiniPlayer:
- **Swipe left / right**: Skip to next / previous track.
- **Swipe up**: Open full screen player.
- **Swipe down**: Close / dismiss miniplayer (stops playback and clears queue).
- **Smooth physics**: Real-time visual drag tracking with spring-back animation and bounded resistance.
- **Haptic feedback**: Tactile confirmation when a gesture threshold is reached.
- **Tap & button safety**: Tap to open and playback controls (Previous, Play/Pause, Next) continue to work seamlessly without gesture conflict.

## Checklist
- [x] Swipe to open/dismiss
- [x] Fix overlap in settings and playlist
- [x] Swipe left right for skip
- [x] Swipe down to close